### PR TITLE
add draft-16 to package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
 
-    name = "oauth2app",
+    name = "oauth2app-draft-16",
 
     version = "0.3.0",
 


### PR DESCRIPTION
In order to distinguish this from other (future, to be released) draft implementations, I've added "draft-16" to the name. After a fair bit of discussion, we decided this was the least crazy way to keep the draft versions straight.
