### PR TITLE
Fix issue when requesting token with grant_type client_credentials

### DIFF
--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -409,6 +409,6 @@ class TokenGenerator(object):
         if self.authentication_method == MAC:
             access_token.mac_key = KeyGenerator(MAC_KEY_LENGTH)()
         access_ranges = AccessRange.objects.filter(key__in=self.scope) if self.scope else []
-        self.access_token.scope = access_ranges
-        self.access_token.save()
-        return self.access_token
+        access_token.scope = access_ranges
+        access_token.save()
+        return access_token

--- a/tests/testsite/apps/api/tests/__init__.py
+++ b/tests/testsite/apps/api/tests/__init__.py
@@ -5,4 +5,5 @@ from .json import JSONTestCase
 from .mac import MACTestCase
 from .bearer import BearerTestCase
 from .responsetype import ResponseTypeTestCase
+from .granttype import GrantTypeTestCase
 from .config import ConfigTestCase

--- a/tests/testsite/apps/api/tests/granttype.py
+++ b/tests/testsite/apps/api/tests/granttype.py
@@ -1,0 +1,59 @@
+#-*- coding: utf-8 -*-
+
+from simplejson import loads
+from base64 import b64encode
+from django.utils import unittest
+from django.contrib.auth.models import User
+from oauth2app.models import Client
+from django.test.client import Client as DjangoTestClient
+
+
+USER_USERNAME = "testuser"
+USER_PASSWORD = "testpassword"
+USER_EMAIL = "user@example.com"
+USER_FIRSTNAME = "Foo"
+USER_LASTNAME = "Bar"
+CLIENT_USERNAME = "client"
+CLIENT_EMAIL = "client@example.com"
+REDIRECT_URI = "http://example.com/callback"
+
+
+class GrantTypeTestCase(unittest.TestCase):
+
+    user = None
+    client_holder = None
+    client_application = None
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            USER_USERNAME,
+            USER_EMAIL,
+            USER_PASSWORD)
+        self.user.first_name = USER_FIRSTNAME
+        self.user.last_name = USER_LASTNAME
+        self.user.save()
+        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client_application = Client.objects.create(
+            name="TestApplication",
+            user=self.client)
+
+    def tearDown(self):
+        self.user.delete()
+        self.client.delete()
+        self.client_application.delete()
+
+    def test_00_grant_type_client_credentials(self):
+        user = DjangoTestClient()
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
+        client = DjangoTestClient()
+        parameters = {
+            "client_id": self.client_application.key,
+            "grant_type": "client_credentials",
+            "redirect_uri": REDIRECT_URI}
+        basic_auth = b64encode("%s:%s" % (self.client_application.key,
+            self.client_application.secret))
+        response = client.get(
+            "/oauth2/token",
+            parameters,
+            HTTP_AUTHORIZATION="Basic %s" % basic_auth)
+        token = loads(response.content)


### PR DESCRIPTION
Came across an issue when requesting a token using the client_credentials grant_type.

Offending code was token.py, _get_client_credentials_token, line 412

Exception was "NoneType has no attribute "scope". Turns out when using client_credentials, the code was creating a new access_token object, but was trying to assign to self.access_token instead of the newly created in-scope object. I removed the references to self in the code. 

Verified with new unit test GrantTypeTestCase.test_00_grant_type_client_credentials
