### PR TITLE
Remove callback verification

### DIFF
--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -81,7 +81,7 @@ class Client(models.Model):
         unique=True,
         max_length=CLIENT_SECRET_LENGTH,
         default=KeyGenerator(CLIENT_SECRET_LENGTH))
-    redirect_uri = models.URLField(null=True)
+    redirect_uri = models.URLField(verify_exists=False, null=True)
 
 
 class AccessRange(models.Model):
@@ -184,7 +184,7 @@ class Code(models.Model):
         default=TimestampGenerator())
     expire = models.PositiveIntegerField(
         default=TimestampGenerator(CODE_EXPIRATION))
-    redirect_uri = models.URLField(null=True)
+    redirect_uri = models.URLField(verify_exists=False, null=True)
     scope = models.ManyToManyField(AccessRange)
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
 
     name = "oauth2app-draft-16",
 
-    version = "0.3.0",
+    version = "0.3.1",
 
     packages = find_packages(),
 


### PR DESCRIPTION
if using Django 1.3, this prevents the security issue that is fixed in 1.3.1 and also allows use of localhost as a callback endpoint for testing.

This behaviour is the default for Django 1.3.1+
