### PR TITLE
Changed parameter name bearer_token to access_token

### DIFF
--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -90,7 +90,7 @@ class Authenticator(object):
 
         *Returns None*"""
         self.request = request
-        self.bearer_token = request.REQUEST.get('bearer_token')
+        self.bearer_token = request.REQUEST.get('access_token')
         if "HTTP_AUTHORIZATION" in self.request.META:
             auth = self.request.META["HTTP_AUTHORIZATION"].split()
             self.auth_type = auth[0].lower()


### PR DESCRIPTION
see http://self-issued.info/docs/draft-ietf-oauth-v2-bearer.html#anchor19 
`-06  Changed parameter name bearer_token to access_token, per working group consensus.`
