### PR TITLE
Made AccessRange.key length configurable

### DIFF
--- a/oauth2app/consts.py
+++ b/oauth2app/consts.py
@@ -12,6 +12,8 @@ from .exceptions import OAuth2Exception
 CLIENT_KEY_LENGTH = getattr(settings, "OAUTH2_CLIENT_KEY_LENGTH", 30)
 # Length of the client secret.
 CLIENT_SECRET_LENGTH = getattr(settings, "OAUTH2_CLIENT_SECRET_LENGTH", 30)
+# Length of the scope key.
+SCOPE_LENGTH = getattr(settings, "OAUTH2_SCOPE_LENGTH", 255)
 # Length of the code key.
 CODE_KEY_LENGTH = getattr(settings, "OAUTH2_CODE_KEY_LENGTH", 30)
 # Length of the MAC authentication key.

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from django.db import models
 from django.contrib.auth.models import User
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
+from .consts import SCOPE_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
 from .consts import ACCESS_TOKEN_EXPIRATION, MAC_KEY_LENGTH, REFRESHABLE
 from .consts import CODE_KEY_LENGTH, CODE_EXPIRATION
@@ -98,7 +99,7 @@ class AccessRange(models.Model):
       *Default None*
 
     """
-    key = models.CharField(unique=True, max_length=255, db_index=True)
+    key = models.CharField(unique=True, max_length=SCOPE_LENGTH, db_index=True)
     description = models.TextField(blank=True)
 
 


### PR DESCRIPTION
Guess AccessRange.key length isn't configurable because it's mostly used with static pre-defined set of ranges.

I'm implementing [Unhosted](http://unhosted.org/) [remoteStorage](http://www.w3.org/community/unhosted/wiki/RemoteStorage) protocol server (mk-fg/django-unhosted), and "scope" parameter there is basically a path (think "public/image.jpg"), and thus can easly be larger than 255 characters, hence the need for larger (preferrably configurable) field.
