### PR TITLE
Removed django-uni-forms requirement from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,11 @@
 from setuptools import setup, find_packages
 
 
-requirements = [l.strip() for l in open('requirements.txt').readlines()]
-
-
 setup(
     name="oauth2app",
     version="0.3.0",
     packages=find_packages(),
-    install_requires=requirements,
+    install_requires=['Django>=1.2.3', 'simplejson>=2.1.5'],
     include_package_data=True,
 
     # metadata for upload to PyPI


### PR DESCRIPTION
It's only used in example, so there's little sense in installing it to every non-development system using oauth2app.

requirements.txt still retains it though, since it's intended to be more precise and complete list - a snapshot of development environment.
