### PR TITLE
Custom Client model

### DIFF
--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -4,7 +4,11 @@
 """OAuth 2.0 Authorization"""
 
 
-from django.http import absolute_http_url_re, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseRedirect
+try:
+    from django.http.request import absolute_http_url_re  # Django 1.5+
+except ImportError:
+    from django.http import absolute_http_url_re
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -9,13 +9,15 @@ try:
     from django.http.request import absolute_http_url_re  # Django 1.5+
 except ImportError:
     from django.http import absolute_http_url_re
+from django.db.models.loading import get_model
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN
 from .consts import AUTHENTICATION_METHOD, MAC, BEARER, MAC_KEY_LENGTH
+from .consts import CLIENT_MODEL
 from .exceptions import OAuth2Exception
 from .lib.uri import add_parameters, add_fragments, normalize
-from .models import Client, AccessRange, Code, AccessToken, KeyGenerator
+from .models import AccessRange, Code, AccessToken, KeyGenerator
 
 
 class AuthorizationException(OAuth2Exception):
@@ -172,11 +174,13 @@ class Authorizer(object):
 
     def _validate(self):
         """Validate the request."""
+        ClientModel = get_model(*CLIENT_MODEL.split('.', 1))
+
         if self.client_id is None:
             raise InvalidRequest('No client_id')
         try:
-            self.client = Client.objects.get(key=self.client_id)
-        except Client.DoesNotExist:
+            self.client = ClientModel.objects.get(key=self.client_id)
+        except ClientModel.DoesNotExist:
             raise InvalidClient("client_id %s doesn't exist" % self.client_id)
         # Redirect URI
         if self.redirect_uri is None:

--- a/oauth2app/consts.py
+++ b/oauth2app/consts.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from .exceptions import OAuth2Exception
 
 
+# Client model.
+CLIENT_MODEL = getattr(settings, 'OAUTH2_CLIENT_MODEL', 'oauth2app.Client')
 # Length of the client key.
 CLIENT_KEY_LENGTH = getattr(settings, "OAUTH2_CLIENT_KEY_LENGTH", 30)
 # Length of the client secret.
@@ -26,20 +28,20 @@ REFRESHABLE = getattr(settings, "OAUTH2_REFRESHABLE", True)
 CODE_EXPIRATION = getattr(settings, "OAUTH2_CODE_EXPIRATION", 120)
 # Number of seconds in which an access token should expire.
 ACCESS_TOKEN_EXPIRATION = getattr(
-    settings, 
-    "OAUTH2_ACCESS_TOKEN_EXPIRATION", 
+    settings,
+    "OAUTH2_ACCESS_TOKEN_EXPIRATION",
     3600)
-# Sends and accepts Bearer style authentication parameters 
+# Sends and accepts Bearer style authentication parameters
 # See http://tools.ietf.org/html/draft-ietf-oauth-saml2-bearer-03
 # and http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-04
 BEARER = 1
-# Sends and accepts MAC style authentication parameters 
+# Sends and accepts MAC style authentication parameters
 # See http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-00
-MAC = 2 
+MAC = 2
 # Type of authentication to use. Bearer or MAC.
 AUTHENTICATION_METHOD = getattr(
-    settings, 
-    "OAUTH2_AUTHENTICATION_METHOD", 
+    settings,
+    "OAUTH2_AUTHENTICATION_METHOD",
     BEARER)
 if AUTHENTICATION_METHOD not in [BEARER, MAC]:
     raise OAuth2Exception("Possible values for OAUTH2_AUTHENTICATION_METHOD "

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -9,6 +9,7 @@ from hashlib import sha512
 from uuid import uuid4
 from django.db import models
 from django.conf import settings
+from .consts import CLIENT_MODEL
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
 from .consts import ACCESS_TOKEN_EXPIRATION, MAC_KEY_LENGTH, REFRESHABLE
@@ -127,7 +128,7 @@ class AccessToken(models.Model):
       refreshable. *Default False*
 
     """
-    client = models.ForeignKey(Client)
+    client = models.ForeignKey(CLIENT_MODEL)
     user = models.ForeignKey(AUTH_USER_MODEL)
     token = models.CharField(
         unique=True,
@@ -175,7 +176,7 @@ class Code(models.Model):
     * *scope:* A list of oauth2app.models.AccessRange objects. *Default None*
 
     """
-    client = models.ForeignKey(Client)
+    client = models.ForeignKey(CLIENT_MODEL)
     user = models.ForeignKey(AUTH_USER_MODEL)
     key = models.CharField(
         unique=True,

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -8,11 +8,14 @@ import time
 from hashlib import sha512
 from uuid import uuid4
 from django.db import models
-from django.contrib.auth.models import User
+from django.conf import settings
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
 from .consts import ACCESS_TOKEN_EXPIRATION, MAC_KEY_LENGTH, REFRESHABLE
 from .consts import CODE_KEY_LENGTH, CODE_EXPIRATION
+
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 class TimestampGenerator(object):
@@ -54,7 +57,7 @@ class Client(models.Model):
     **Args:**
 
     * *name:* A string representing the client name.
-    * *user:* A django.contrib.auth.models.User object representing the client
+    * *user:* A Django User object representing the client
        owner.
 
     **Kwargs:**
@@ -70,7 +73,7 @@ class Client(models.Model):
 
     """
     name = models.CharField(max_length=256)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     description = models.TextField(null=True, blank=True)
     key = models.CharField(
         unique=True,
@@ -108,7 +111,7 @@ class AccessToken(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -125,7 +128,7 @@ class AccessToken(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     token = models.CharField(
         unique=True,
         max_length=ACCESS_TOKEN_LENGTH,
@@ -159,7 +162,7 @@ class Code(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -173,7 +176,7 @@ class Code(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     key = models.CharField(
         unique=True,
         max_length=CODE_KEY_LENGTH,

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -2,7 +2,10 @@
 
 try: import simplejson as json
 except ImportError: import json
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 from django.utils import unittest
@@ -27,14 +30,14 @@ class BaseTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -6,7 +6,10 @@ from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 
@@ -28,14 +31,14 @@ class MACTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/responsetype.py
+++ b/tests/testsite/apps/api/tests/responsetype.py
@@ -5,8 +5,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib import auth
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -21,39 +23,39 @@ REDIRECT_URI = "http://example.com/callback"
 
 
 class ResponseTypeTestCase(unittest.TestCase):
-    
+
     user = None
     client_holder = None
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
-            USER_USERNAME, 
-            USER_EMAIL, 
+        self.user = (get_user_model() or User).objects.create_user(
+            USER_USERNAME,
+            USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
-        self.client_application = Client.objects.create(    
-            name="TestApplication", 
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client_application = Client.objects.create(
+            name="TestApplication",
             user=self.client)
 
     def tearDown(self):
         self.user.delete()
         self.client.delete()
         self.client_application.delete()
-    
+
     def test_00_code(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
             "response_type":"code"}
         response = user.get("/oauth2/authorize_code?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
-        self.assertTrue("code" in qs) 
+        self.assertTrue("code" in qs)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -61,10 +63,10 @@ class ResponseTypeTestCase(unittest.TestCase):
         response = user.get("/oauth2/authorize_code?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
         self.assertTrue("error" in qs)
-                
+
     def test_01_token(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -82,7 +84,7 @@ class ResponseTypeTestCase(unittest.TestCase):
 
     def test_02_token_mac(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -93,7 +95,7 @@ class ResponseTypeTestCase(unittest.TestCase):
 
     def test_03_code_and_token(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -112,7 +114,7 @@ class ResponseTypeTestCase(unittest.TestCase):
         self.assertTrue("code" not in qs)
         fs = parse_qs(urlparse(response['location']).fragment)
         self.assertTrue("access_token" in fs)
-        
+
     def test_04_invalid_response_type(self):
         user = DjangoTestClient()
         user.login(username=USER_USERNAME, password=USER_PASSWORD)
@@ -122,4 +124,4 @@ class ResponseTypeTestCase(unittest.TestCase):
             "response_type":"blah"}
         response = user.get("/oauth2/authorize_code_and_token?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
-        self.assertTrue("error" in qs)   
+        self.assertTrue("error" in qs)

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -7,7 +7,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -28,14 +31,14 @@ class ScopeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/settings.py
+++ b/tests/testsite/settings.py
@@ -62,6 +62,7 @@ TEMPLATE_LOADERS = (
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
+    'django.contrib.auth.context_processors.auth',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/tests/testsite/urls.py
+++ b/tests/testsite/urls.py
@@ -4,5 +4,4 @@ from django.conf import settings
 urlpatterns = patterns('',
     (r'^oauth2/', include('testsite.apps.oauth2.urls')),
     (r'^api/', include('testsite.apps.api.urls')),
-    (r'^account/', include('testsite.apps.account.urls')),
 )


### PR DESCRIPTION
Adds a setting `OAUTH2_CLIENT_MODEL` allowing the use of a custom client model instead of `oauth2app.models.Client`, for cases where the client might not be owned by a user, or where additional fields are required.

Since the Client is read-only during the auth flow, things like `redirect_uri`, `name`, etc can even be implemented as properties rather than fields.

Use via:

```
OAUTH2_CLIENT_MODEL='myapp.MyClient'
```

The branch is based off the [Django 1.5 support branch](https://github.com/hiidef/oauth2app/pull/38), but doesn't require it.
