### PR TITLE
Handle malformed Authorization headers without a 500.

### DIFF
--- a/examples/mysite/apps/base/views.py
+++ b/examples/mysite/apps/base/views.py
@@ -8,13 +8,13 @@ from oauth2app.models import Client, AccessToken
 
 def homepage(request):
     template = {}
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         clients = Client.objects.filter(user=request.user)
         access_tokens = AccessToken.objects.filter(user=request.user)
         access_tokens = access_tokens.select_related()
         template["access_tokens"] = access_tokens
         template["clients"] = clients
     return render_to_response(
-        'base/homepage.html', 
-        template, 
+        'base/homepage.html',
+        template,
         RequestContext(request))

--- a/examples/mysite/settings.py
+++ b/examples/mysite/settings.py
@@ -90,7 +90,11 @@ INSTALLED_APPS = (
     'mysite.apps.oauth2',
     'mysite.apps.api',
     'uni_form',
-    'oauth2app')
+    'oauth2app',
+    'django_nose',
+)
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 LOGGING = {
     'version': 1,

--- a/oauth2app/admin.py
+++ b/oauth2app/admin.py
@@ -1,0 +1,27 @@
+import time
+import datetime
+
+from django.contrib import admin
+from django.template.defaultfilters import timeuntil
+
+from oauth2app.models import Client, AccessToken, AccessRange
+
+class ClientAdmin(admin.ModelAdmin):
+    list_display = ('name', 'user', 'description', 'key', 'redirect_uri')
+
+class AccessTokenAdmin(admin.ModelAdmin):
+    list_display = ('user', 'client_name', 'remaining', 'refreshable')
+    
+    def client_name(self, obj):
+        return obj.client.name
+    
+    def remaining(self, obj):
+        remaining = int(obj.expire - time.time())
+        return timeuntil(datetime.datetime.fromtimestamp(obj.expire)) if remaining > 0 else 'expired'
+
+class AccessRangeAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(Client, ClientAdmin)
+admin.site.register(AccessToken, AccessTokenAdmin)
+admin.site.register(AccessRange, AccessRangeAdmin)

--- a/oauth2app/admin.py
+++ b/oauth2app/admin.py
@@ -2,7 +2,7 @@ import time
 import datetime
 
 from django.contrib import admin
-from django.template.defaultfilters import timeuntil
+from django.template.defaultfilters import timeuntil, timesince
 
 from oauth2app.models import Client, AccessToken, AccessRange
 
@@ -17,7 +17,10 @@ class AccessTokenAdmin(admin.ModelAdmin):
     
     def remaining(self, obj):
         remaining = int(obj.expire - time.time())
-        return timeuntil(datetime.datetime.fromtimestamp(obj.expire)) if remaining > 0 else 'expired'
+        if remaining > 0:
+            return timeuntil(datetime.datetime.fromtimestamp(obj.expire))
+        else:
+            return "expired {0} ago".format(timesince(datetime.datetime.fromtimestamp(obj.expire)))
 
 class AccessRangeAdmin(admin.ModelAdmin):
     pass

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -99,7 +99,7 @@ class Authenticator(object):
         self.request_port = self.request.META.get("SERVER_PORT")
         try:
             self._validate()
-        except AuthenticationException, e:
+        except AuthenticationException as e:
             self.error = e
             raise e
         self.valid = True

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -120,7 +120,6 @@ class Authenticator(object):
             self.attempted_validation = True
             self._validate_bearer(self.bearer_token)
             self.valid = True
-            return
         else:
             raise InvalidRequest("Request authentication failed, no "
                 "authentication credentials provided.")

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -92,7 +92,7 @@ class Authenticator(object):
         *Returns None*"""
         self.request = request
         self.bearer_token = request.REQUEST.get('bearer_token')
-        if "HTTP_AUTHORIZATION" in self.request.META:
+        if self.request.META.get("HTTP_AUTHORIZATION"):
             auth = self.request.META["HTTP_AUTHORIZATION"].split()
             self.auth_type = auth[0].lower()
             self.auth_value = " ".join(auth[1:]).strip()

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -6,7 +6,8 @@
 
 from hashlib import sha256
 from urlparse import parse_qsl
-from json import dumps
+try: import simplejson as json
+except ImportError: import json
 from django.conf import settings
 from django.http import HttpResponse
 from .exceptions import OAuth2Exception
@@ -51,8 +52,8 @@ class Authenticator(object):
       the scope the authenticator will authenticate.
       *Default None*
     * *authentication_method:* Accepted authentication methods. Possible
-      values are: oauth2app.consts.MAC, oauth2app.consts.BEARER, 
-      oauth2app.consts.MAC | oauth2app.consts.BEARER, 
+      values are: oauth2app.consts.MAC, oauth2app.consts.BEARER,
+      oauth2app.consts.MAC | oauth2app.consts.BEARER,
       *Default oauth2app.consts.BEARER*
 
     """
@@ -65,11 +66,11 @@ class Authenticator(object):
     attempted_validation = False
 
     def __init__(
-            self, 
-            scope=None, 
-            authentication_method=AUTHENTICATION_METHOD):         
+            self,
+            scope=None,
+            authentication_method=AUTHENTICATION_METHOD):
         if authentication_method not in [BEARER, MAC, BEARER | MAC]:
-            raise OAuth2Exception("Possible values for authentication_method" 
+            raise OAuth2Exception("Possible values for authentication_method"
                 " are oauth2app.consts.MAC, oauth2app.consts.BEARER, "
                 "oauth2app.consts.MAC | oauth2app.consts.BEARER")
         self.authentication_method = authentication_method
@@ -167,7 +168,7 @@ class Authenticator(object):
         nonce_timestamp, nonce_string = mac_header["nonce"].split(":")
         mac = sha256("\n".join([
             mac_header["nonce"], # The nonce value generated for the request
-            self.request.method.upper(), # The HTTP request method 
+            self.request.method.upper(), # The HTTP request method
             "XXX", # The HTTP request-URI
             self.request_hostname, # The hostname included in the HTTP request
             self.request_port, # The port as included in the HTTP request
@@ -186,7 +187,7 @@ class Authenticator(object):
         # the determination of staleness is left up to the server to
         # define).
         # 3.  Verify the scope and validity of the MAC credentials.
-        
+
 
     def _get_user(self):
         """The user associated with the valid access token.
@@ -280,16 +281,16 @@ class JSONAuthenticator(Authenticator):
 
     * *scope:* A iterable of oauth2app.models.AccessRange objects.
     """
-    
+
     callback = None
-    
+
     def __init__(self, scope=None):
         Authenticator.__init__(self, scope=scope)
-        
+
     def validate(self, request):
         self.callback = request.REQUEST.get('callback')
         return Authenticator.validate(self, request)
-        
+
     def response(self, data):
         """Returns a HttpResponse object of JSON serialized data.
 
@@ -297,7 +298,7 @@ class JSONAuthenticator(Authenticator):
 
         * *data:* Object to be JSON serialized and returned.
         """
-        json_data = dumps(data)
+        json_data = json.dumps(data)
         if self.callback is not None:
             json_data = "%s(%s);" % (self.callback, json_data)
         response = HttpResponse(
@@ -308,7 +309,7 @@ class JSONAuthenticator(Authenticator):
     def error_response(self):
         """Returns a HttpResponse object of JSON error data."""
         if self.error is not None:
-            content = dumps({
+            content = json.dumps({
                 "error":getattr(self.error, "error", "invalid_request"),
                 "error_description":self.error.message})
         else:

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -7,7 +7,7 @@ import time
 try: import simplejson as json
 except ImportError: import json
 from hashlib import sha256
-from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 from django.conf import settings
 from django.http import HttpResponse
 from .exceptions import OAuth2Exception
@@ -91,7 +91,7 @@ class Authenticator(object):
 
         *Returns None*"""
         self.request = request
-        self.bearer_token = request.REQUEST.get('bearer_token')
+        self.bearer_token = request.POST.get('bearer_token') or request.GET.get('bearer_token')
         if self.request.META.get("HTTP_AUTHORIZATION"):
             auth = self.request.META["HTTP_AUTHORIZATION"].split()
             self.auth_type = auth[0].lower()

--- a/oauth2app/authenticate.py
+++ b/oauth2app/authenticate.py
@@ -6,7 +6,7 @@
 
 from hashlib import sha256
 from urlparse import parse_qsl
-from simplejson import dumps
+from json import dumps
 from django.conf import settings
 from django.http import HttpResponse
 from .exceptions import OAuth2Exception

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -28,7 +28,7 @@ class MissingRedirectURI(OAuth2Exception):
 
 class UnauthenticatedUser(OAuth2Exception):
     """The provided user is not internally authenticated, via
-    user.is_authenticated()"""
+    user.is_authenticated"""
     pass
 
 
@@ -279,7 +279,7 @@ class Authorizer(object):
         if not self.valid:
             raise UnvalidatedRequest("This request is invalid or has not "
                 "been validated.")
-        if self.user.is_authenticated():
+        if self.user.is_authenticated:
             parameters = {}
             fragments = {}
             if self.scope is not None:

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -4,7 +4,11 @@
 """OAuth 2.0 Authorization"""
 
 
-from django.http import absolute_http_url_re, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseRedirect
+try:
+    from django.http.request import absolute_http_url_re  # Django 1.5+
+except ImportError:
+    from django.http import absolute_http_url_re
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -4,7 +4,6 @@
 """OAuth 2.0 Authorization"""
 
 
-import simplejson as json
 from django.http import absolute_http_url_re, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -3,13 +3,10 @@
 
 """OAuth 2.0 Authorization"""
 
+import re
 
 from django.http import HttpResponseRedirect
-try:
-    from django.http.request import absolute_http_url_re  # Django 1.5+
-except ImportError:
-    from django.http import absolute_http_url_re
-from urllib import urlencode
+from urllib.parse import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN
 from .consts import AUTHENTICATION_METHOD, MAC, BEARER, MAC_KEY_LENGTH
@@ -17,6 +14,7 @@ from .exceptions import OAuth2Exception
 from .lib.uri import add_parameters, add_fragments, normalize
 from .models import Client, AccessRange, Code, AccessToken, KeyGenerator
 
+absolute_http_url_re = re.compile(r"^https?://", re.I)
 
 class AuthorizationException(OAuth2Exception):
     """Authorization exception base class."""

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -204,7 +204,10 @@ class Authorizer(object):
         if self.authorized_scope is not None and self.scope is None:
             self.scope = self.authorized_scope
         if self.scope is not None:
-            self.access_ranges = AccessRange.objects.filter(key__in=self.scope)
+            if self.client.all_scopes_allowable:
+                self.access_ranges = AccessRange.objects.filter(key__in=self.scope)
+            else:
+                self.access_ranges = self.client.allowable_scopes.filter(key__in=self.scope)
             access_ranges = set(self.access_ranges.values_list('key', flat=True))
             difference = access_ranges.symmetric_difference(self.scope)
             if len(difference) != 0:

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -133,7 +133,7 @@ class Authorizer(object):
         *Returns HTTP Response redirect*"""
         try:
             self.validate(request)
-        except AuthorizationException, e:
+        except AuthorizationException:
             # The request is malformed or invalid. Automatically
             # redirects to the provided redirect URL.
             return self.error_redirect()
@@ -160,7 +160,7 @@ class Authorizer(object):
         self.request = request
         try:
             self._validate()
-        except AuthorizationException, e:
+        except AuthorizationException as e:
             self._check_redirect_uri()
             self.error = e
             raise e

--- a/oauth2app/backends.py
+++ b/oauth2app/backends.py
@@ -24,6 +24,7 @@ class OAuth2ProxyUser(User):
     last_name = property(lambda self: self.user.last_name)
     is_active = property(lambda self: self.user.is_active)
     date_joined = property(lambda self: self.user.date_joined)
+    groups = property(lambda self: self.user.groups)
 
     # Only allow a client to act as staff or a superuser if one of its scopes
     # enables it to do so.

--- a/oauth2app/backends.py
+++ b/oauth2app/backends.py
@@ -1,0 +1,55 @@
+"""
+Authentication backend that uses AccessRange groups to filter access.
+"""
+
+from django.contrib.auth.models import User 
+
+class OAuth2ProxyUser(User):
+    """
+    A proxy in front of the actual User that restricts access based on
+    AccessRange permission_users.
+    """
+    def __init__(self, access_token):
+        self.access_token = access_token
+        self.user, self.client = access_token.user, access_token.client
+        
+        scopes = list(access_token.scope.all())
+        self.scopes = [scope.key for scope in scopes]
+        self.scope_users = [scope.permission_user for scope in scopes
+                            if scope.permission_user and scope.permission_user.is_active]
+    
+    fk = property(lambda self: self.user.fk)
+    username = property(lambda self: self.user.username)
+    first_name = property(lambda self: self.user.first_name)
+    last_name = property(lambda self: self.user.last_name)
+    is_active = property(lambda self: self.user.is_active)
+    date_joined = property(lambda self: self.user.date_joined)
+
+    # Only allow a client to act as staff or a superuser if one of its scopes
+    # enables it to do so.    
+    @property
+    def is_staff(self):
+        return self.user.is_staff \
+            and any(u.is_staff for u in self.scope_users)
+    @property
+    def is_superuser(self):
+        return self.user.is_superuser \
+            and any(u.is_superuser for u in self.scope_users)
+
+    def get_all_permissions(self, obj=None):
+        print "GAP", obj
+        perms = set()
+        for u in self.scope_users:
+            perms |= u.get_all_permissions(obj)
+        perms &= self.user.get_all_permissions(obj)
+        return perms
+
+    def has_perm(self, perm, obj=None):
+        print "HP", obj
+        return self.user.has_perm(perm, obj) \
+            and any(u.has_perm(perm, obj) for u in self.scope_users)
+
+    def has_perms(self, perm_list, obj=None):
+        print "HP", obj
+        return self.user.has_perms(perm_list, obj) \
+            and any(u.has_perms(perm_list, obj) for u in self.scope_users)

--- a/oauth2app/forms.py
+++ b/oauth2app/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+
+class AuthorizeForm(forms.Form):
+    redirect_uri = forms.CharField(widget=forms.HiddenInput)
+    client_id = forms.CharField(widget=forms.HiddenInput)
+    response_type = forms.CharField(widget=forms.HiddenInput)
+    scope = forms.CharField(widget=forms.HiddenInput, required=False)

--- a/oauth2app/lib/uri.py
+++ b/oauth2app/lib/uri.py
@@ -4,9 +4,8 @@
 """OAuth 2.0 URI Helper Functions"""
 
 
-from urlparse import urlparse, urlunparse, parse_qsl
-from urllib import urlencode
-from url_normalize import url_normalize
+from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
+from .url_normalize import url_normalize
  
  
 def add_parameters(url, parameters):

--- a/oauth2app/lib/url_normalize.py
+++ b/oauth2app/lib/url_normalize.py
@@ -32,8 +32,7 @@ __version__ = 1.1
 
 import re
 import unicodedata
-import urlparse
-from urllib import quote, unquote
+import urllib.parse
 
 
 def url_normalize(url, charset='utf-8'):
@@ -50,7 +49,7 @@ def url_normalize(url, charset='utf-8'):
     """
 
     def _clean(string):
-        string = unicode(unquote(string), 'utf-8', 'replace')
+        string = str(urllib.parse.unquote(string), 'utf-8', 'replace')
         return unicodedata.normalize('NFC', string).encode('utf-8')
 
     default_port = {
@@ -65,7 +64,7 @@ def url_normalize(url, charset='utf-8'):
         'snews': 563,
         'snntp': 563,
     }
-    if isinstance(url, unicode):
+    if isinstance(url, str):
         url = url.encode(charset, 'ignore')
 
     # if there is no scheme use http as default scheme
@@ -96,7 +95,7 @@ def url_normalize(url, charset='utf-8'):
     fragment = quote(_clean(fragment), "~")
 
     # note care must be taken to only encode & and = characters as values
-    query = "&".join(["=".join([quote(_clean(t), "~:/?#[]@!$'()*+,;=") for t in q.split("=", 1)]) for q in query.split("&")])
+    query = "&".join(["=".join([urllib.parse.quote(_clean(t), "~:/?#[]@!$'()*+,;=") for t in q.split("=", 1)]) for q in query.split("&")])
 
     # Prevent dot-segments appearing in non-relative URI paths.
     if scheme in ["", "http", "https", "ftp", "file"]:
@@ -140,7 +139,7 @@ def url_normalize(url, charset='utf-8'):
         auth += ":" + port
     if url.endswith("#") and query == "" and fragment == "":
         path += "#"
-    return urlparse.urlunsplit((scheme, auth, path, query, fragment))
+    return urllib.parse.urlunsplit((scheme, auth, path, query, fragment))
 
 if __name__ == "__main__":
     import unittest

--- a/oauth2app/middleware.py
+++ b/oauth2app/middleware.py
@@ -17,8 +17,9 @@ class OAuth2Middleware(object):
             request.user = OAuth2ProxyUser(authenticator.access_token)
 
     def process_response(self, request, response):
-        if isinstance(request.user, OAuth2ProxyUser):
-            response['X-OAuth2-Scopes'] = ' '.join(request.user.scopes)
+        user = getattr(request, 'user', None)
+        if user:
+            response['X-OAuth2-Scopes'] = ' '.join(user.scopes)
 
         if response.status_code == httplib.UNAUTHORIZED:
             authenticate = response.get('WWW-Authenticate', None)

--- a/oauth2app/middleware.py
+++ b/oauth2app/middleware.py
@@ -1,0 +1,32 @@
+import httplib
+
+from oauth2app.authenticate import Authenticator, AuthenticationException
+from oauth2app.consts import REALM
+from .backends import OAuth2ProxyUser
+
+class OAuth2Middleware(object):
+    def process_request(self, request):
+        authenticator = Authenticator()
+        #import pdb;pdb.set_trace()
+        try:
+            authenticator.validate(request)
+        except AuthenticationException, e:
+            if authenticator.bearer_token or authenticator.auth_type in ['bearer', 'mac']:
+                return authenticator.error_response(content="You didn't authenticate.")
+        else:
+            request.user = OAuth2ProxyUser(authenticator.access_token)
+
+    def process_response(self, request, response):
+        if isinstance(request.user, OAuth2ProxyUser):
+            response['X-OAuth2-Scopes'] = ' '.join(request.user.scopes)
+
+        if response.status_code == httplib.UNAUTHORIZED:
+            authenticate = response.get('WWW-Authenticate', None)
+            if 'Bearer realm="' not in authenticate:
+                if authenticate:
+                    authenticate = 'Bearer realm="%s", %s' % (REALM, authenticate)
+                else:
+                    authenticate = 'Bearer realm="%s"' % REALM
+            response['WWW-Authenticate'] = authenticate
+
+        return response

--- a/oauth2app/middleware.py
+++ b/oauth2app/middleware.py
@@ -1,4 +1,4 @@
-import httplib
+import http.client
 
 from oauth2app.authenticate import Authenticator, AuthenticationException
 from oauth2app.consts import REALM
@@ -7,10 +7,9 @@ from .backends import OAuth2ProxyUser
 class OAuth2Middleware(object):
     def process_request(self, request):
         authenticator = Authenticator()
-        #import pdb;pdb.set_trace()
         try:
             authenticator.validate(request)
-        except AuthenticationException, e:
+        except AuthenticationException as e:
             if authenticator.bearer_token or authenticator.auth_type in ['bearer', 'mac']:
                 return authenticator.error_response(content="You didn't authenticate.")
         else:
@@ -21,7 +20,7 @@ class OAuth2Middleware(object):
         if user and hasattr(user, 'scopes'):
             response['X-OAuth2-Scopes'] = ' '.join(user.scopes)
 
-        if response.status_code == httplib.UNAUTHORIZED:
+        if response.status_code == http.client.UNAUTHORIZED:
             authenticate = response.get('WWW-Authenticate', None)
             if 'Bearer realm="' not in authenticate:
                 if authenticate:

--- a/oauth2app/middleware.py
+++ b/oauth2app/middleware.py
@@ -1,10 +1,11 @@
 import http.client
 
+from django.utils.deprecation import MiddlewareMixin
 from oauth2app.authenticate import Authenticator, AuthenticationException
 from oauth2app.consts import REALM
 from .backends import OAuth2ProxyUser
 
-class OAuth2Middleware(object):
+class OAuth2Middleware(MiddlewareMixin):
     def process_request(self, request):
         authenticator = Authenticator()
         try:

--- a/oauth2app/middleware.py
+++ b/oauth2app/middleware.py
@@ -18,7 +18,7 @@ class OAuth2Middleware(object):
 
     def process_response(self, request, response):
         user = getattr(request, 'user', None)
-        if user:
+        if user and hasattr(user, 'scopes'):
             response['X-OAuth2-Scopes'] = ' '.join(user.scopes)
 
         if response.status_code == httplib.UNAUTHORIZED:

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -9,7 +9,7 @@ from hashlib import sha512
 from uuid import uuid4
 from django.db import models
 from django.conf import settings
-from django.db.models import get_model
+from django.apps import apps
 from django.contrib.auth.hashers import make_password
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import SCOPE_LENGTH
@@ -119,7 +119,7 @@ class AccessRange(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.permission_user:
-            user_model = get_model(*AUTH_USER_MODEL.split('.'))
+            user_model = apps.get_model(*AUTH_USER_MODEL.split('.'))
             self.permission_user = user_model.objects.create(
                 username=SCOPE_USER_PREFIX + uuid4().hex[:16],
                 first_name='OAuth2 permissions granted by',

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -105,7 +105,8 @@ class AccessRange(models.Model):
     """
     key = models.CharField(unique=True, max_length=255, db_index=True)
     description = models.TextField(blank=True)
-
+    ttl = models.BigIntegerField(null=True, blank=True,
+                                 help_text="Number of seconds before this scope is removed from an access token.")
 
 class AccessToken(models.Model):
     """Stores access token data.

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from django.db import models
 from django.conf import settings
 from django.db.models import get_model
-from django.contrib.auth.models import UNUSABLE_PASSWORD
+from django.contrib.auth.hashers import make_password
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import SCOPE_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
@@ -124,7 +124,7 @@ class AccessRange(models.Model):
                 username=SCOPE_USER_PREFIX + uuid4().hex[:16],
                 first_name='OAuth2 permissions granted by',
                 last_name=self.key,
-                password=UNUSABLE_PASSWORD)
+                password=make_password(None))
         super(AccessRange, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -70,6 +70,7 @@ class Client(models.Model):
       random string*
     * *redirect_uri:* A string representing the client redirect_uri.
       *Default None*
+    * *auto_authorize:* Don't ask the user to confirm authorization.
 
     """
     name = models.CharField(max_length=256)
@@ -85,6 +86,7 @@ class Client(models.Model):
         max_length=CLIENT_SECRET_LENGTH,
         default=KeyGenerator(CLIENT_SECRET_LENGTH))
     redirect_uri = models.URLField(null=True)
+    auto_authorize = models.BooleanField()
 
 
 class AccessRange(models.Model):

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -77,7 +77,7 @@ class Client(models.Model):
 
     """
     name = models.CharField(max_length=256)
-    user = models.ForeignKey(AUTH_USER_MODEL)
+    user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)
     description = models.TextField(null=True, blank=True)
     key = models.CharField(
         unique=True,
@@ -113,7 +113,7 @@ class AccessRange(models.Model):
     label = models.CharField(max_length=255)
     description = models.TextField(blank=True)
     permission_user = models.ForeignKey(AUTH_USER_MODEL, null=True, blank=True,
-                                        help_text="An auto-created user whose permissions this scope allows access to.")
+                                        help_text="An auto-created user whose permissions this scope allows access to.", on_delete=models.CASCADE)
     ttl = models.BigIntegerField(null=True, blank=True,
                                  help_text="Number of seconds before this scope is removed from an access token.")
 
@@ -152,8 +152,8 @@ class AccessToken(models.Model):
       refreshable. *Default False*
 
     """
-    client = models.ForeignKey(Client)
-    user = models.ForeignKey(AUTH_USER_MODEL)
+    client = models.ForeignKey(Client, on_delete=models.CASCADE)
+    user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)
     token = models.CharField(
         unique=True,
         max_length=ACCESS_TOKEN_LENGTH,
@@ -200,8 +200,8 @@ class Code(models.Model):
     * *scope:* A list of oauth2app.models.AccessRange objects. *Default None*
 
     """
-    client = models.ForeignKey(Client)
-    user = models.ForeignKey(AUTH_USER_MODEL)
+    client = models.ForeignKey(Client, on_delete=models.CASCADE)
+    user = models.ForeignKey(AUTH_USER_MODEL, on_delete=models.CASCADE)
     key = models.CharField(
         unique=True,
         max_length=CODE_KEY_LENGTH,
@@ -225,5 +225,5 @@ class MACNonce(models.Model):
     * *nonce:* A unique nonce string.
 
     """
-    access_token = models.ForeignKey(AccessToken)
+    access_token = models.ForeignKey(AccessToken, on_delete=models.CASCADE)
     nonce = models.CharField(max_length=30, db_index=True)

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -89,7 +89,7 @@ class Client(models.Model):
         default=KeyGenerator(CLIENT_SECRET_LENGTH))
     redirect_uri = models.URLField(null=True)
     auto_authorize = models.BooleanField()
-    
+
     all_scopes_allowable = models.BooleanField()
     allowable_scopes = models.ManyToManyField('AccessRange', blank=True)
 
@@ -115,7 +115,7 @@ class AccessRange(models.Model):
                                         help_text="An auto-created user whose permissions this scope allows access to.")
     ttl = models.BigIntegerField(null=True, blank=True,
                                  help_text="Number of seconds before this scope is removed from an access token.")
-    
+
     def save(self, *args, **kwargs):
         if not self.permission_user:
             user_model = get_model(*AUTH_USER_MODEL.split('.'))
@@ -125,6 +125,9 @@ class AccessRange(models.Model):
                 last_name=self.key,
                 password=UNUSABLE_PASSWORD)
         super(AccessRange, self).save(*args, **kwargs)
+
+    def __unicode__(self):
+        return self.key
 
 class AccessToken(models.Model):
     """Stores access token data.

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -109,6 +109,7 @@ class AccessRange(models.Model):
 
     """
     key = models.CharField(unique=True, max_length=255, db_index=True)
+    label = models.CharField(max_length=255)
     description = models.TextField(blank=True)
     permission_user = models.ForeignKey(AUTH_USER_MODEL, null=True, blank=True,
                                         help_text="An auto-created user whose permissions this scope allows access to.")

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -87,6 +87,9 @@ class Client(models.Model):
         default=KeyGenerator(CLIENT_SECRET_LENGTH))
     redirect_uri = models.URLField(null=True)
     auto_authorize = models.BooleanField()
+    
+    all_scopes_allowable = models.BooleanField()
+    allowable_scopes = models.ManyToManyField('AccessRange', blank=True)
 
 
 class AccessRange(models.Model):

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -8,11 +8,14 @@ import time
 from hashlib import sha512
 from uuid import uuid4
 from django.db import models
-from django.contrib.auth.models import User
+from django.conf import settings
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
 from .consts import ACCESS_TOKEN_EXPIRATION, MAC_KEY_LENGTH, REFRESHABLE
 from .consts import CODE_KEY_LENGTH, CODE_EXPIRATION
+
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 class TimestampGenerator(object):
@@ -54,7 +57,7 @@ class Client(models.Model):
     **Args:**
 
     * *name:* A string representing the client name.
-    * *user:* A django.contrib.auth.models.User object representing the client
+    * *user:* A Django User object representing the client
        owner.
 
     **Kwargs:**
@@ -70,7 +73,7 @@ class Client(models.Model):
 
     """
     name = models.CharField(max_length=256)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     description = models.TextField(null=True, blank=True)
     key = models.CharField(
         unique=True,
@@ -108,7 +111,7 @@ class AccessToken(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -125,7 +128,7 @@ class AccessToken(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     token = models.CharField(
         unique=True,
         max_length=ACCESS_TOKEN_LENGTH,
@@ -159,7 +162,7 @@ class Code(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -173,7 +176,7 @@ class Code(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     key = models.CharField(
         unique=True,
         max_length=CODE_KEY_LENGTH,

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -51,7 +51,7 @@ class KeyGenerator(object):
         self.length = length
 
     def __call__(self):
-        return sha512(uuid4().hex).hexdigest()[0:self.length]
+        return sha512(uuid4().hex.encode('utf-8')).hexdigest()[0:self.length]
 
 
 class Client(models.Model):

--- a/oauth2app/templates/oauth2app/authorize.html
+++ b/oauth2app/templates/oauth2app/authorize.html
@@ -1,0 +1,23 @@
+{% extends "oauth2app/base.html" %}
+
+{% block content %}
+<h1>Authorize external OAuth application?</h1>
+
+<form method="post" action="{% url "oauth2app:authorize" %}">{% csrf_token %}
+  <p>The application <strong id="client-name">{{ client.name }}</strong>,
+     provided by <strong id="client-owner">{% if client.user.first_name or client.user.last_name %}{{ client.user.first_name }}
+     {{ client.user.last_name }}{% else %}{{ client.user.username }}{% endif %}</strong>, {{ authorizer }}
+     would like permission to{% if not access_ranges %} act on your behalf. It has asked for no specific permissions, and so its access will be very limited.</p>{% else %}:</p>
+     
+     <dl>{% for access_range in access_ranges %}
+       <dt data-scope="{{ access_range.key }}">{{ access_range.label }}</dt>{% if access_range.description or access_range.ttl %}
+       <dd>{{ access_range.description }}{% if access_range.description and access_range.ttl %}<br>{% endif %}{% if access_range.ttl %}
+       <em>Once granted, this permission will expire in {{ access_range.ttl }} seconds.</em>{% endif %}</dd>{% endif %}{% endfor %}
+     </dl>{% endif %}
+
+     Are you happy for this to happen?</p>
+  {{ form }}
+  <input type="submit" name="accept" value="Yes"/>
+  <input type="submit" name="decline" value="No"/>
+</form>
+{% endblock %}

--- a/oauth2app/templates/oauth2app/base.html
+++ b/oauth2app/templates/oauth2app/base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/oauth2app/templates/oauth2app/missing-redirect-url.html
+++ b/oauth2app/templates/oauth2app/missing-redirect-url.html
@@ -1,0 +1,5 @@
+{% extends "oauth2app/base.html" %}
+
+{% block content %}
+<h1>Missing redirect URL</h1>
+{% endblock %}

--- a/oauth2app/tests/test_authenticate.py
+++ b/oauth2app/tests/test_authenticate.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from nose.tools import assert_raises
+
+from oauth2app.authenticate import Authenticator
+
+
+class AuthenticateTestCase(TestCase):
+    def setUp(self):
+        self.authenticator = Authenticator(authentication_method='')
+        class Request(object): pass
+        self.request = Request()
+
+    def test_invalid_request(self):
+        self.request.bearer_token = 'herp'
+        assert_raises(self.authenticator.validate, 'self.request')
+

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -10,7 +10,7 @@ from django.contrib.auth import authenticate
 from django.views.decorators.csrf import csrf_exempt
 from json import dumps
 from .exceptions import OAuth2Exception
-from .consts import ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_LENGTH
+from .consts import ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_LENGTH, ACCESS_TOKEN_LENGTH
 from .consts import AUTHENTICATION_METHOD, MAC, BEARER, MAC_KEY_LENGTH
 from .consts import REFRESHABLE
 from .lib.uri import normalize
@@ -393,6 +393,7 @@ class TokenGenerator(object):
 
     def _get_refresh_token(self):
         """Generate an access token after refresh authorization."""
+        self.access_token.token = KeyGenerator(ACCESS_TOKEN_LENGTH)()
         self.access_token.refresh_token = KeyGenerator(REFRESH_TOKEN_LENGTH)()
         self.access_token.expire = TimestampGenerator(ACCESS_TOKEN_EXPIRATION)()
         access_ranges = AccessRange.objects.filter(key__in=self.scope) if self.scope else []

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -401,8 +401,8 @@ class TokenGenerator(object):
         self.access_token.token = KeyGenerator(ACCESS_TOKEN_LENGTH)()
         self.access_token.refresh_token = KeyGenerator(REFRESH_TOKEN_LENGTH)()
         self.access_token.expire = TimestampGenerator(ACCESS_TOKEN_EXPIRATION)()
-        access_ranges = AccessRange.objects.filter(key__in=self.scope) if self.scope else []
-        self.access_token.scope = access_ranges
+        if self.scope is not None:
+            self.access_token.scope = AccessRange.objects.filter(key__in=self.scope)
         self.access_token.save()
         return self.access_token
 

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -212,13 +212,17 @@ class TokenGenerator(object):
         """Validate the request's access credentials."""
         if self.client_secret is None and "HTTP_AUTHORIZATION" in self.request.META:
             authorization = self.request.META["HTTP_AUTHORIZATION"]
-            auth_type, auth_value = authorization.split()[0:2]
-            if auth_type.lower() == "basic":
-                credentials = "%s:%s" % (self.client.key, self.client.secret)
-                if auth_value != b64encode(credentials):
-                    raise InvalidClient('Client authentication failed.')
-            else:
+            try:
+                auth_type, auth_value = authorization.split()[:2]
+            except ValueError: # malformed Authorization header
                 raise InvalidClient('Client authentication failed.')
+            else:
+                if auth_type.lower() == "basic":
+                    credentials = "%s:%s" % (self.client.key, self.client.secret)
+                    if auth_value != b64encode(credentials):
+                        raise InvalidClient('Client authentication failed.')
+                else:
+                    raise InvalidClient('Client authentication failed.')
         elif self.client_secret != self.client.secret:
             raise InvalidClient('Client authentication failed.')
 

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -8,7 +8,7 @@ from base64 import b64encode
 from django.http import HttpResponse
 from django.contrib.auth import authenticate
 from django.views.decorators.csrf import csrf_exempt
-from simplejson import dumps
+from json import dumps
 from .exceptions import OAuth2Exception
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_LENGTH
 from .consts import AUTHENTICATION_METHOD, MAC, BEARER, MAC_KEY_LENGTH

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -8,7 +8,8 @@ from base64 import b64encode
 from django.http import HttpResponse
 from django.contrib.auth import authenticate
 from django.views.decorators.csrf import csrf_exempt
-from json import dumps
+try: import simplejson as json
+except ImportError: import json
 from .exceptions import OAuth2Exception
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_LENGTH, ACCESS_TOKEN_LENGTH
 from .consts import AUTHENTICATION_METHOD, MAC, BEARER, MAC_KEY_LENGTH
@@ -313,7 +314,7 @@ class TokenGenerator(object):
         else:
             e = InvalidRequest("Access Denied.")
         data = {'error': e.error, 'error_description': u'%s' % e.message}
-        json_data = dumps(data)
+        json_data = json.dumps(data)
         if self.callback is not None:
             json_data = "%s(%s);" % (self.callback, json_data)
             return HttpResponse(
@@ -355,7 +356,7 @@ class TokenGenerator(object):
             data['refresh_token'] = access_token.refresh_token
         if self.scope is not None:
             data['scope'] = ' '.join(self.scope)
-        json_data = dumps(data)
+        json_data = json.dumps(data)
         if self.callback is not None:
             json_data = "%s(%s);" % (self.callback, json_data)
         response = HttpResponse(

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -155,7 +155,7 @@ class TokenGenerator(object):
         self.request = request
         try:
             self.validate()
-        except AccessTokenException, e:
+        except AccessTokenException:
             return self.error_response()
         return self.grant_response()
 
@@ -166,7 +166,7 @@ class TokenGenerator(object):
         *Returns None*"""
         try:
             self._validate()
-        except AccessTokenException, e:
+        except AccessTokenException as e:
             self.error = e
             raise e
         self.valid = True

--- a/oauth2app/urls.py
+++ b/oauth2app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 from . import views
 

--- a/oauth2app/urls.py
+++ b/oauth2app/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls.defaults import url, patterns
+
+from . import views
+
+urlpatterns = patterns('',
+    url(r'^authorize/$', views.AuthorizeView.as_view(), name='authorize'),
+    url(r'^token/$', 'oauth2app.token.handler', name='token'),
+)

--- a/oauth2app/urls.py
+++ b/oauth2app/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from . import views
+from .token import handler as token_handler
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^authorize/$', views.AuthorizeView.as_view(), name='authorize'),
-    url(r'^token/$', 'oauth2app.token.handler', name='token'),
-)
+    url(r'^token/$', token_handler, name='token'),
+]

--- a/oauth2app/urls.py
+++ b/oauth2app/urls.py
@@ -3,6 +3,8 @@ from django.conf.urls import url
 from . import views
 from .token import handler as token_handler
 
+app_name = 'oauth2app'
+
 urlpatterns = [
     url(r'^authorize/$', views.AuthorizeView.as_view(), name='authorize'),
     url(r'^token/$', token_handler, name='token'),

--- a/oauth2app/views.py
+++ b/oauth2app/views.py
@@ -1,0 +1,58 @@
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.utils.decorators import method_decorator
+
+from django.views.generic import TemplateView, View
+from django.views.generic.base import TemplateResponseMixin
+
+
+from oauth2app.authorize import Authorizer, MissingRedirectURI, AuthorizationException
+from django_conneg.views import HTMLView
+
+from . import forms
+
+
+class MissingRedirectURLView(TemplateView):
+    template_name = 'oauth2app/missing-redirect-url.html'
+    
+class AuthorizeView(TemplateResponseMixin, View):
+    template_name = 'oauth2app/authorize.html'
+    
+    missing_redirect_url_view = staticmethod(MissingRedirectURLView.as_view())
+
+    @method_decorator(login_required)
+    def dispatch(self, request):
+        self.authorizer = Authorizer()
+        try:
+            self.authorizer.validate(request)
+        except MissingRedirectURI, e:
+            return self.missing_redirect_url_view(request)
+        except AuthorizationException, e:
+            # The request is malformed or invalid. Automatically
+            # redirects to the provided redirect URL.
+            return self.authorizer.error_redirect()
+        return super(AuthorizeView, self).dispatch(request)
+    
+    def get_context_data(self):
+        #import pdb;pdb.set_trace()
+        return {'authorizer': self.authorizer,
+                'access_ranges': self.authorizer.access_ranges,
+                'client': self.authorizer.client,
+                'form': forms.AuthorizeForm(self.request.POST or \
+                                            self.request.GET or None)}
+
+    def get(self, request):
+        context = self.get_context_data()
+        if self.authorizer.client.auto_authorize:
+            return self.authorizer.grant_redirect()
+        return self.render_to_response(context)
+
+    def post(self, request):
+        context = self.get_context_data()
+        if context['form'].is_valid():
+            if 'accept' in request.POST:
+                return self.authorizer.grant_redirect()
+            else:
+                return self.authorizer.error_redirect()
+        return HttpResponseBadRequest()

--- a/oauth2app/views.py
+++ b/oauth2app/views.py
@@ -26,9 +26,9 @@ class AuthorizeView(TemplateResponseMixin, View):
         self.authorizer = Authorizer()
         try:
             self.authorizer.validate(request)
-        except MissingRedirectURI, e:
+        except MissingRedirectURI as e:
             return self.missing_redirect_url_view(request)
-        except AuthorizationException, e:
+        except AuthorizationException as e:
             # The request is malformed or invalid. Automatically
             # redirects to the provided redirect URL.
             return self.authorizer.error_redirect()

--- a/oauth2app/views.py
+++ b/oauth2app/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 
@@ -15,10 +15,10 @@ from . import forms
 
 class MissingRedirectURLView(TemplateView):
     template_name = 'oauth2app/missing-redirect-url.html'
-    
+
 class AuthorizeView(TemplateResponseMixin, View):
     template_name = 'oauth2app/authorize.html'
-    
+
     missing_redirect_url_view = staticmethod(MissingRedirectURLView.as_view())
 
     @method_decorator(login_required)
@@ -33,7 +33,7 @@ class AuthorizeView(TemplateResponseMixin, View):
             # redirects to the provided redirect URL.
             return self.authorizer.error_redirect()
         return super(AuthorizeView, self).dispatch(request)
-    
+
     def get_context_data(self):
         #import pdb;pdb.set_trace()
         return {'authorizer': self.authorizer,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
 
     packages = find_packages(),
 
-    install_requires = ['Django>=1.2.3', 'simplejson>=2.1.5', "django-uni-form>=0.8.0"],
+    install_requires = ['Django>=1.2.3', "django-uni-form>=0.8.0"],
     include_package_data = True,
 
     # metadata for upload to PyPI

--- a/tests/testsite/apps/api/tests/__init__.py
+++ b/tests/testsite/apps/api/tests/__init__.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 
 from .scope import ScopeTestCase
-from .json import JSONTestCase
+from .test_json import JSONTestCase
 from .mac import MACTestCase
 from .bearer import BearerTestCase
 from .responsetype import ResponseTypeTestCase

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
+import json
 from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
@@ -64,4 +64,4 @@ class BaseTestCase(unittest.TestCase):
             "/oauth2/token", 
             parameters, 
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
-        return loads(response.content)["access_token"]
+        return json.loads(response.content)["access_token"]

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -2,7 +2,10 @@
 
 try: import simplejson as json
 except ImportError: import json
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 from django.utils import unittest
@@ -27,14 +30,14 @@ class BaseTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 
-import json
+try: import simplejson as json
+except ImportError: import json
 from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
@@ -20,32 +21,32 @@ REDIRECT_URI = "http://example.com/callback"
 
 
 class BaseTestCase(unittest.TestCase):
-    
+
     user = None
     client_holder = None
     client_application = None
 
     def setUp(self):
         self.user = User.objects.create_user(
-            USER_USERNAME, 
-            USER_EMAIL, 
+            USER_USERNAME,
+            USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
         self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
-        self.client_application = Client.objects.create(    
-            name="TestApplication", 
+        self.client_application = Client.objects.create(
+            name="TestApplication",
             user=self.client)
-    
+
     def tearDown(self):
         self.user.delete()
         self.client.delete()
         self.client_application.delete()
-        
+
     def get_token(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -61,7 +62,7 @@ class BaseTestCase(unittest.TestCase):
             "redirect_uri":REDIRECT_URI}
         basic_auth = b64encode("%s:%s" % (self.client_application.key, self.client_application.secret))
         response = client.get(
-            "/oauth2/token", 
-            parameters, 
+            "/oauth2/token",
+            parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         return json.loads(response.content)["access_token"]

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -4,6 +4,7 @@ try: import simplejson as json
 except ImportError: import json
 try:
     from django.contrib.auth import get_user_model  # Django 1.5+
+    User = get_user_model()
 except:
     from django.contrib.auth.models import User
 from oauth2app.models import Client
@@ -30,14 +31,14 @@ class BaseTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = (get_user_model() or User).objects.create_user(
+        self.user = User.objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/bearer.py
+++ b/tests/testsite/apps/api/tests/bearer.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
+import json
 from .base import *
 
 
@@ -33,19 +33,19 @@ class BearerTestCase(BaseTestCase):
             {}, 
             HTTP_AUTHORIZATION="Bearer %s" % token)
         self.assertEqual(response.status_code, 200) 
-        self.assertTrue("email" in loads(response.content))
+        self.assertTrue("email" in json.loads(response.content))
         response = client.get(
             "/api/email_json", 
             {}, 
             HTTP_AUTHORIZATION="Bearer2 %s" % token)
         self.assertEqual(response.status_code, 401)
-        self.assertTrue("error" in loads(response.content))
+        self.assertTrue("error" in json.loads(response.content))
         response = client.get(
             "/api/email_json", 
             {}, 
             HTTP_AUTHORIZATION="Bearer !!!%s" % token)
         self.assertEqual(response.status_code, 401)
-        self.assertTrue("error" in loads(response.content))
+        self.assertTrue("error" in json.loads(response.content))
 
     def test_02_automatic_fail(self):
         client = DjangoTestClient()

--- a/tests/testsite/apps/api/tests/bearer.py
+++ b/tests/testsite/apps/api/tests/bearer.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 
-import json
+try: import simplejson as json
+except ImportError: import json
 from .base import *
 
 
@@ -10,18 +11,18 @@ class BearerTestCase(BaseTestCase):
         client = DjangoTestClient()
         token = self.get_token()
         response = client.get(
-            "/api/email_str", 
-            {}, 
+            "/api/email_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         response = client.get(
-            "/api/email_str", 
-            {}, 
+            "/api/email_str",
+            {},
             HTTP_AUTHORIZATION="Bearer2 %s" % token)
         self.assertEqual(response.status_code, 401)
         response = client.get(
-            "/api/email_str", 
-            {}, 
+            "/api/email_str",
+            {},
             HTTP_AUTHORIZATION="Bearer !!!%s" % token)
         self.assertEqual(response.status_code, 401)
 
@@ -29,20 +30,20 @@ class BearerTestCase(BaseTestCase):
         client = DjangoTestClient()
         token = self.get_token()
         response = client.get(
-            "/api/email_json", 
-            {}, 
+            "/api/email_json",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertTrue("email" in json.loads(response.content))
         response = client.get(
-            "/api/email_json", 
-            {}, 
+            "/api/email_json",
+            {},
             HTTP_AUTHORIZATION="Bearer2 %s" % token)
         self.assertEqual(response.status_code, 401)
         self.assertTrue("error" in json.loads(response.content))
         response = client.get(
-            "/api/email_json", 
-            {}, 
+            "/api/email_json",
+            {},
             HTTP_AUTHORIZATION="Bearer !!!%s" % token)
         self.assertEqual(response.status_code, 401)
         self.assertTrue("error" in json.loads(response.content))
@@ -51,12 +52,12 @@ class BearerTestCase(BaseTestCase):
         client = DjangoTestClient()
         token = self.get_token()
         response = client.get(
-            "/api/automatic_error_str", 
-            {}, 
+            "/api/automatic_error_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
         self.assertEqual(response.status_code, 401)
         response = client.get(
-            "/api/automatic_error_json", 
-            {}, 
+            "/api/automatic_error_json",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
         self.assertEqual(response.status_code, 401)

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
+import json
 from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
@@ -65,5 +65,5 @@ class MACTestCase(unittest.TestCase):
             "/oauth2/token_mac", 
             parameters, 
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
-        token = loads(response.content)
+        token = json.loads(response.content)
         

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -6,7 +6,10 @@ from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 
@@ -28,14 +31,14 @@ class MACTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -8,6 +8,7 @@ from urllib import urlencode
 from django.utils import unittest
 try:
     from django.contrib.auth import get_user_model  # Django 1.5+
+    User = get_user_model()
 except:
     from django.contrib.auth.models import User
 from oauth2app.models import Client
@@ -31,14 +32,14 @@ class MACTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = (get_user_model() or User).objects.create_user(
+        self.user = User.objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)
@@ -70,4 +71,3 @@ class MACTestCase(unittest.TestCase):
             parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         token = json.loads(response.content)
-

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 
-import json
+try: import simplejson as json
+except ImportError: import json
 from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
@@ -21,32 +22,32 @@ REDIRECT_URI = "http://example.com/callback"
 
 
 class MACTestCase(unittest.TestCase):
-    
+
     user = None
     client_holder = None
     client_application = None
 
     def setUp(self):
         self.user = User.objects.create_user(
-            USER_USERNAME, 
-            USER_EMAIL, 
+            USER_USERNAME,
+            USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
         self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
-        self.client_application = Client.objects.create(    
-            name="TestApplication", 
+        self.client_application = Client.objects.create(
+            name="TestApplication",
             user=self.client)
-    
+
     def tearDown(self):
         self.user.delete()
         self.client.delete()
         self.client_application.delete()
-    
+
     def test_00_mac(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -62,8 +63,8 @@ class MACTestCase(unittest.TestCase):
             "redirect_uri":REDIRECT_URI}
         basic_auth = b64encode("%s:%s" % (self.client_application.key, self.client_application.secret))
         response = client.get(
-            "/oauth2/token_mac", 
-            parameters, 
+            "/oauth2/token_mac",
+            parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         token = json.loads(response.content)
-        
+

--- a/tests/testsite/apps/api/tests/responsetype.py
+++ b/tests/testsite/apps/api/tests/responsetype.py
@@ -1,6 +1,5 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
 from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode

--- a/tests/testsite/apps/api/tests/responsetype.py
+++ b/tests/testsite/apps/api/tests/responsetype.py
@@ -5,8 +5,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib import auth
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -21,39 +23,39 @@ REDIRECT_URI = "http://example.com/callback"
 
 
 class ResponseTypeTestCase(unittest.TestCase):
-    
+
     user = None
     client_holder = None
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
-            USER_USERNAME, 
-            USER_EMAIL, 
+        self.user = (get_user_model() or User).objects.create_user(
+            USER_USERNAME,
+            USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
-        self.client_application = Client.objects.create(    
-            name="TestApplication", 
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client_application = Client.objects.create(
+            name="TestApplication",
             user=self.client)
 
     def tearDown(self):
         self.user.delete()
         self.client.delete()
         self.client_application.delete()
-    
+
     def test_00_code(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
             "response_type":"code"}
         response = user.get("/oauth2/authorize_code?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
-        self.assertTrue("code" in qs) 
+        self.assertTrue("code" in qs)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -61,10 +63,10 @@ class ResponseTypeTestCase(unittest.TestCase):
         response = user.get("/oauth2/authorize_code?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
         self.assertTrue("error" in qs)
-                
+
     def test_01_token(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -82,7 +84,7 @@ class ResponseTypeTestCase(unittest.TestCase):
 
     def test_02_token_mac(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -93,7 +95,7 @@ class ResponseTypeTestCase(unittest.TestCase):
 
     def test_03_code_and_token(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "redirect_uri":REDIRECT_URI,
@@ -112,7 +114,7 @@ class ResponseTypeTestCase(unittest.TestCase):
         self.assertTrue("code" not in qs)
         fs = parse_qs(urlparse(response['location']).fragment)
         self.assertTrue("access_token" in fs)
-        
+
     def test_04_invalid_response_type(self):
         user = DjangoTestClient()
         user.login(username=USER_USERNAME, password=USER_PASSWORD)
@@ -122,4 +124,4 @@ class ResponseTypeTestCase(unittest.TestCase):
             "response_type":"blah"}
         response = user.get("/oauth2/authorize_code_and_token?%s" % urlencode(parameters))
         qs = parse_qs(urlparse(response['location']).query)
-        self.assertTrue("error" in qs)   
+        self.assertTrue("error" in qs)

--- a/tests/testsite/apps/api/tests/responsetype.py
+++ b/tests/testsite/apps/api/tests/responsetype.py
@@ -7,6 +7,7 @@ from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
 try:
     from django.contrib.auth import get_user_model  # Django 1.5+
+    User = get_user_model()
 except:
     from django.contrib.auth.models import User
 from oauth2app.models import Client
@@ -29,14 +30,14 @@ class ResponseTypeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = (get_user_model() or User).objects.create_user(
+        self.user = User.objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
+import json
 from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
@@ -68,7 +68,7 @@ class ScopeTestCase(unittest.TestCase):
             "/oauth2/token", 
             parameters, 
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
-        token = loads(response.content)["access_token"]
+        token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
             "/api/first_name_str", 
@@ -112,7 +112,7 @@ class ScopeTestCase(unittest.TestCase):
             "/oauth2/token", 
             parameters, 
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
-        token = loads(response.content)["access_token"]
+        token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
             "/api/email_str", 
@@ -158,7 +158,7 @@ class ScopeTestCase(unittest.TestCase):
             "/oauth2/token", 
             parameters, 
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
-        token = loads(response.content)["access_token"]
+        token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
             "/api/first_and_last_name_str", 

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -7,7 +7,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -28,14 +31,14 @@ class ScopeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -9,6 +9,7 @@ from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
 try:
     from django.contrib.auth import get_user_model  # Django 1.5+
+    User = get_user_model()
 except:
     from django.contrib.auth.models import User
 from oauth2app.models import Client
@@ -31,14 +32,14 @@ class ScopeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = (get_user_model() or User).objects.create_user(
+        self.user = User.objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)
@@ -176,4 +177,3 @@ class ScopeTestCase(unittest.TestCase):
             HTTP_AUTHORIZATION="Bearer %s" % token)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, USER_FIRSTNAME)
-

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -1,12 +1,12 @@
 #-*- coding: utf-8 -*-
 
-import json
+try: import simplejson as json
+except ImportError: import json
 from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib import auth
 from django.contrib.auth.models import User
 from oauth2app.models import Client
 
@@ -22,22 +22,22 @@ REDIRECT_URI = "http://example.com/callback"
 
 
 class ScopeTestCase(unittest.TestCase):
-    
+
     user = None
     client_holder = None
     client_application = None
 
     def setUp(self):
         self.user = User.objects.create_user(
-            USER_USERNAME, 
-            USER_EMAIL, 
+            USER_USERNAME,
+            USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
         self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
-        self.client_application = Client.objects.create(    
-            name="TestApplication", 
+        self.client_application = Client.objects.create(
+            name="TestApplication",
             user=self.client)
 
     def tearDown(self):
@@ -47,7 +47,7 @@ class ScopeTestCase(unittest.TestCase):
 
     def test_00_first_name_scope(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "scope":"first_name",
@@ -65,32 +65,32 @@ class ScopeTestCase(unittest.TestCase):
             "scope":"first_name"}
         basic_auth = b64encode("%s:%s" % (self.client_application.key, self.client_application.secret))
         response = client.get(
-            "/oauth2/token", 
-            parameters, 
+            "/oauth2/token",
+            parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
-            "/api/first_name_str", 
-            {}, 
+            "/api/first_name_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, USER_FIRSTNAME)
         # Insufficient scope for last_name
         response = client.get(
-            "/api/last_name_str", 
-            {}, 
-            HTTP_AUTHORIZATION="Bearer %s" % token)     
-        self.assertEqual(response.status_code, 403)   
+            "/api/last_name_str",
+            {},
+            HTTP_AUTHORIZATION="Bearer %s" % token)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue("insufficient_scope" in str(response))
         # Insufficient scope for first_name, last_name
         response = client.get(
-            "/api/first_and_last_name_str", 
-            {}, 
-            HTTP_AUTHORIZATION="Bearer %s" % token)     
-        self.assertEqual(response.status_code, 403)   
+            "/api/first_and_last_name_str",
+            {},
+            HTTP_AUTHORIZATION="Bearer %s" % token)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue("insufficient_scope" in str(response))
-    
+
     def test_01_no_scope(self):
         user = DjangoTestClient()
         user.login(username=USER_USERNAME, password=USER_PASSWORD)
@@ -109,35 +109,35 @@ class ScopeTestCase(unittest.TestCase):
             "redirect_uri":REDIRECT_URI}
         basic_auth = b64encode("%s:%s" % (self.client_application.key, self.client_application.secret))
         response = client.get(
-            "/oauth2/token", 
-            parameters, 
+            "/oauth2/token",
+            parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
-            "/api/email_str", 
-            {}, 
+            "/api/email_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, USER_EMAIL)
         # Insufficient scope for first_name, last_name
         response = client.get(
-            "/api/first_and_last_name_str", 
-            {}, 
-            HTTP_AUTHORIZATION="Bearer %s" % token)     
-        self.assertEqual(response.status_code, 403)   
+            "/api/first_and_last_name_str",
+            {},
+            HTTP_AUTHORIZATION="Bearer %s" % token)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue("insufficient_scope" in str(response))
         # Insufficient scope for last_name
         response = client.get(
-            "/api/last_name_str", 
-            {}, 
-            HTTP_AUTHORIZATION="Bearer %s" % token)     
-        self.assertEqual(response.status_code, 403)   
+            "/api/last_name_str",
+            {},
+            HTTP_AUTHORIZATION="Bearer %s" % token)
+        self.assertEqual(response.status_code, 403)
         self.assertTrue("insufficient_scope" in str(response))
 
     def test_02_dual_scope(self):
         user = DjangoTestClient()
-        user.login(username=USER_USERNAME, password=USER_PASSWORD)      
+        user.login(username=USER_USERNAME, password=USER_PASSWORD)
         parameters = {
             "client_id":self.client_application.key,
             "scope":"first_name last_name",
@@ -155,22 +155,22 @@ class ScopeTestCase(unittest.TestCase):
             "scope":"first_name last_name"}
         basic_auth = b64encode("%s:%s" % (self.client_application.key, self.client_application.secret))
         response = client.get(
-            "/oauth2/token", 
-            parameters, 
+            "/oauth2/token",
+            parameters,
             HTTP_AUTHORIZATION="Basic %s" % basic_auth)
         token = json.loads(response.content)["access_token"]
         # Sufficient scope.
         response = client.get(
-            "/api/first_and_last_name_str", 
-            {}, 
+            "/api/first_and_last_name_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, USER_FIRSTNAME + " " + USER_LASTNAME)
         # Sufficient scope.
         response = client.get(
-            "/api/first_name_str", 
-            {}, 
+            "/api/first_name_str",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, USER_FIRSTNAME)
-        
+

--- a/tests/testsite/apps/api/tests/test_json.py
+++ b/tests/testsite/apps/api/tests/test_json.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from simplejson import loads
+import json
 from .base import *
 
 class JSONTestCase(BaseTestCase):
@@ -14,7 +14,7 @@ class JSONTestCase(BaseTestCase):
             {}, 
             HTTP_AUTHORIZATION="Bearer %s" % token)
         self.assertEqual(response.status_code, 200) 
-        self.assertEqual(loads(response.content)["email"], USER_EMAIL)
+        self.assertEqual(json.loads(response.content)["email"], USER_EMAIL)
         response = client.get(
             "/api/email_json?callback=foo", 
             {}, 
@@ -22,11 +22,11 @@ class JSONTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 200) 
         # Remove the JSON callback.
         content = response.content.replace("foo(", "").replace(");", "")
-        self.assertEqual(loads(content)["email"], USER_EMAIL)
+        self.assertEqual(json.loads(content)["email"], USER_EMAIL)
         response = client.get(
             "/api/email_json?callback=foo", 
             {}, 
             HTTP_AUTHORIZATION="Bearer !!!%s" % token)
         content = response.content.replace("foo(", "").replace(");", "")
         self.assertEqual(response.status_code, 200) 
-        self.assertTrue("error" in loads(content))
+        self.assertTrue("error" in json.loads(content))

--- a/tests/testsite/apps/api/tests/test_json.py
+++ b/tests/testsite/apps/api/tests/test_json.py
@@ -1,32 +1,33 @@
 #-*- coding: utf-8 -*-
 
-import json
+try: import simplejson as json
+except ImportError: import json
 from .base import *
 
 class JSONTestCase(BaseTestCase):
-    
+
     def test_00_email(self):
         client = DjangoTestClient()
         token = self.get_token()
         # Sufficient scope.
         response = client.get(
-            "/api/email_json", 
-            {}, 
+            "/api/email_json",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content)["email"], USER_EMAIL)
         response = client.get(
-            "/api/email_json?callback=foo", 
-            {}, 
+            "/api/email_json?callback=foo",
+            {},
             HTTP_AUTHORIZATION="Bearer %s" % token)
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         # Remove the JSON callback.
         content = response.content.replace("foo(", "").replace(");", "")
         self.assertEqual(json.loads(content)["email"], USER_EMAIL)
         response = client.get(
-            "/api/email_json?callback=foo", 
-            {}, 
+            "/api/email_json?callback=foo",
+            {},
             HTTP_AUTHORIZATION="Bearer !!!%s" % token)
         content = response.content.replace("foo(", "").replace(");", "")
-        self.assertEqual(response.status_code, 200) 
+        self.assertEqual(response.status_code, 200)
         self.assertTrue("error" in json.loads(content))

--- a/tests/testsite/settings.py
+++ b/tests/testsite/settings.py
@@ -62,6 +62,7 @@ TEMPLATE_LOADERS = (
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
+    'django.contrib.auth.context_processors.auth',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/tests/testsite/settings.py
+++ b/tests/testsite/settings.py
@@ -11,12 +11,12 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', 
-        'NAME': 'testsite.sqlite',      
-        'USER': '',      
-        'PASSWORD': '',  
-        'HOST': '',      
-        'PORT': '',      
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'testsite.sqlite',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
     }
 }
 
@@ -105,10 +105,10 @@ LOGGING = {
     }
 }
 
-TEST_RUNNER = 'django-test-coverage.runner.run_tests'
-COVERAGE_MODULES = (
-    'oauth2app.authenticate', 
-    'oauth2app.authorize', 
-    'oauth2app.models', 
-    'oauth2app.token',
-    'oauth2app.lib.uri',)
+# TEST_RUNNER = 'django-test-coverage.runner.run_tests'
+# COVERAGE_MODULES = (
+#     'oauth2app.authenticate',
+#     'oauth2app.authorize',
+#     'oauth2app.models',
+#     'oauth2app.token',
+#     'oauth2app.lib.uri',)

--- a/tests/testsite/urls.py
+++ b/tests/testsite/urls.py
@@ -4,5 +4,4 @@ from django.conf import settings
 urlpatterns = patterns('',
     (r'^oauth2/', include('testsite.apps.oauth2.urls')),
     (r'^api/', include('testsite.apps.api.urls')),
-    (r'^account/', include('testsite.apps.account.urls')),
 )


### PR DESCRIPTION
There's an uncaught exception when the Authentication header is empty, as handily pointed out by the Googlebot:

```
Traceback (most recent call last):

  File "/usr/lib/python2.6/dist-packages/django/core/handlers/base.py", line 89, in get_response
    response = middleware_method(request)

  File "/usr/lib/python2.6/dist-packages/dataox/oauth2/middleware.py", line 10, in process_request
    authenticator.validate(request)

  File "/etc/puppet/src/oauth2app/oauth2app/authenticate.py", line 97, in validate
    self.auth_type = auth[0].lower()

IndexError: list index out of range

<WSGIRequest
path:/foo/,
GET:<QueryDict: {}>,
POST:<QueryDict: {}>,
COOKIES:{},
META:{'DOCUMENT_ROOT': '/etc/apache2/htdocs',
 'GATEWAY_INTERFACE': 'CGI/1.1',
 'HTTPS': '1',
 'HTTP_ACCEPT': '*/*',
 'HTTP_ACCEPT_ENCODING': 'gzip,deflate',
 'HTTP_AUTHORIZATION': '',
 'HTTP_CONNECTION': 'Keep-alive',
 'HTTP_FROM': 'googlebot(at)googlebot.com',
 'HTTP_HOST': 'data.ox.ac.uk',
 'HTTP_IF_MODIFIED_SINCE': 'Fri, 11 Jan 2013 04:50:27 GMT',
 'HTTP_USER_AGENT': 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',>
```

I noticed another part susceptible to this problem in oauth2app.token, where an Authentication header that didn't split() into at least two parts would throw an error, which I've also fixed.
