### PR TITLE
Fixed exception with blank redirect_uri(blank string)

### DIFF
--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -177,7 +177,7 @@ class Authorizer(object):
         except Client.DoesNotExist:
             raise InvalidClient("client_id %s doesn't exist" % self.client_id)
         # Redirect URI
-        if self.redirect_uri is None:
+        if not self.redirect_uri:
             if self.client.redirect_uri is None:
                 raise MissingRedirectURI("No redirect_uri"
                     "provided or registered.")

--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -6,7 +6,11 @@
 
 try: import simplejson as json
 except ImportError: import json
-from django.http import absolute_http_url_re, HttpResponseRedirect
+from django.http import HttpResponseRedirect
+try:
+    from django.http.request import absolute_http_url_re  # Django 1.5+
+except ImportError:
+    from django.http import absolute_http_url_re
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN

--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -8,12 +8,15 @@ import time
 from hashlib import sha512
 from uuid import uuid4
 from django.db import models
-from django.contrib.auth.models import User
+from django.conf import settings
 from .consts import CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH
 from .consts import SCOPE_LENGTH
 from .consts import ACCESS_TOKEN_LENGTH, REFRESH_TOKEN_LENGTH
 from .consts import ACCESS_TOKEN_EXPIRATION, MAC_KEY_LENGTH, REFRESHABLE
 from .consts import CODE_KEY_LENGTH, CODE_EXPIRATION
+
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 class TimestampGenerator(object):
@@ -55,7 +58,7 @@ class Client(models.Model):
     **Args:**
 
     * *name:* A string representing the client name.
-    * *user:* A django.contrib.auth.models.User object representing the client
+    * *user:* A Django User object representing the client
        owner.
 
     **Kwargs:**
@@ -71,7 +74,7 @@ class Client(models.Model):
 
     """
     name = models.CharField(max_length=256)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     description = models.TextField(null=True, blank=True)
     key = models.CharField(
         unique=True,
@@ -109,7 +112,7 @@ class AccessToken(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -126,7 +129,7 @@ class AccessToken(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     token = models.CharField(
         unique=True,
         max_length=ACCESS_TOKEN_LENGTH,
@@ -160,7 +163,7 @@ class Code(models.Model):
     **Args:**
 
     * *client:* A oauth2app.models.Client object
-    * *user:* A django.contrib.auth.models.User object
+    * *user:* A Django User object
 
     **Kwargs:**
 
@@ -174,7 +177,7 @@ class Code(models.Model):
 
     """
     client = models.ForeignKey(Client)
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     key = models.CharField(
         unique=True,
         max_length=CODE_KEY_LENGTH,

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -212,7 +212,10 @@ class TokenGenerator(object):
         """Validate the request's access credentials."""
         if self.client_secret is None and "HTTP_AUTHORIZATION" in self.request.META:
             authorization = self.request.META["HTTP_AUTHORIZATION"]
-            auth_type, auth_value = authorization.split()[0:2]
+            try:
+                auth_type, auth_value = authorization.split()[:2]
+            except ValueError:  # malformed Authorization header
+                raise InvalidClient('Client authentication failed.')
             if auth_type.lower() == "basic":
                 credentials = "%s:%s" % (self.client.key, self.client.secret)
                 if auth_value != b64encode(credentials):
@@ -264,7 +267,10 @@ class TokenGenerator(object):
                         "Invalid scope request: %s" % ', '.join(new_scope))
         if "HTTP_AUTHORIZATION" in self.request.META:
             authorization = self.request.META["HTTP_AUTHORIZATION"]
-            auth_type, auth_value = authorization.split()[0:2]
+            try:
+                auth_type, auth_value = authorization.split()[:2]
+            except ValueError:  # malformed Authorization header
+                raise InvalidClient('Client authentication failed.')
             if auth_type.lower() == "basic":
                 credentials = "%s:%s" % (self.client.key, self.client.secret)
                 if auth_value != b64encode(credentials):

--- a/tests/testsite/apps/api/tests/base.py
+++ b/tests/testsite/apps/api/tests/base.py
@@ -2,7 +2,10 @@
 
 try: import simplejson as json
 except ImportError: import json
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 from django.utils import unittest
@@ -27,14 +30,14 @@ class BaseTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/mac.py
+++ b/tests/testsite/apps/api/tests/mac.py
@@ -6,7 +6,10 @@ from base64 import b64encode
 from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 from django.test.client import Client as DjangoTestClient
 
@@ -28,14 +31,14 @@ class MACTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/responsetype.py
+++ b/tests/testsite/apps/api/tests/responsetype.py
@@ -4,7 +4,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -25,14 +28,14 @@ class ResponseTypeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/apps/api/tests/scope.py
+++ b/tests/testsite/apps/api/tests/scope.py
@@ -7,7 +7,10 @@ from urlparse import urlparse, parse_qs
 from urllib import urlencode
 from django.utils import unittest
 from django.test.client import Client as DjangoTestClient
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model  # Django 1.5+
+except:
+    from django.contrib.auth.models import User
 from oauth2app.models import Client
 
 
@@ -28,14 +31,14 @@ class ScopeTestCase(unittest.TestCase):
     client_application = None
 
     def setUp(self):
-        self.user = User.objects.create_user(
+        self.user = (get_user_model() or User).objects.create_user(
             USER_USERNAME,
             USER_EMAIL,
             USER_PASSWORD)
         self.user.first_name = USER_FIRSTNAME
         self.user.last_name = USER_LASTNAME
         self.user.save()
-        self.client = User.objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
+        self.client = (get_user_model() or User).objects.create_user(CLIENT_USERNAME, CLIENT_EMAIL)
         self.client_application = Client.objects.create(
             name="TestApplication",
             user=self.client)

--- a/tests/testsite/settings.py
+++ b/tests/testsite/settings.py
@@ -62,6 +62,7 @@ TEMPLATE_LOADERS = (
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.request',
+    'django.contrib.auth.context_processors.auth',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/tests/testsite/urls.py
+++ b/tests/testsite/urls.py
@@ -4,5 +4,4 @@ from django.conf import settings
 urlpatterns = patterns('',
     (r'^oauth2/', include('testsite.apps.oauth2.urls')),
     (r'^api/', include('testsite.apps.api.urls')),
-    (r'^account/', include('testsite.apps.account.urls')),
 )


### PR DESCRIPTION
Hello. If redirect_uri parameter presents in url but is blank(redirect_uri=&scope....) then
there is the exception in url_normalize function:

if url[0] not in ['/', '-'] and ':' not in url[:7]:
IndexError: string index out of range
