### PR TITLE
Failed to set access_token as attribute

### DIFF
--- a/oauth2app/models.py
+++ b/oauth2app/models.py
@@ -82,6 +82,7 @@ class Client(models.Model):
         unique=True,
         max_length=CLIENT_SECRET_LENGTH,
         default=KeyGenerator(CLIENT_SECRET_LENGTH))
+    can_self_grant = models.BooleanField(default=False)
     redirect_uri = models.URLField(null=True)
 
 

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -210,6 +210,8 @@ class TokenGenerator(object):
 
     def _validate_access_credentials(self):
         """Validate the request's access credentials."""
+        if not self.client.can_self_grant:
+            raise InvalidClient('Client authentication failed.')
         if self.client_secret is None and "HTTP_AUTHORIZATION" in self.request.META:
             authorization = self.request.META["HTTP_AUTHORIZATION"]
             auth_type, auth_value = authorization.split()[0:2]

--- a/oauth2app/token.py
+++ b/oauth2app/token.py
@@ -405,7 +405,7 @@ class TokenGenerator(object):
 
     def _get_client_credentials_token(self):
         """Generate an access token after client_credentials authorization."""
-        access_token = AccessToken.objects.create(
+        self.access_token = AccessToken.objects.create(
             user=self.client.user,
             client=self.client,
             refreshable=self.refreshable)


### PR DESCRIPTION
The client_credentials grant_types fails due to the access_token being incorrectly referenced.

As an important aside, I wouldn't pull this into any version just yet.  As implemented the client_credentials grant_type is a security mess and should never be implemented as it is here.  As is noted here:

http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.4

>    The client credentials grant type MUST only be used by confidential
>    clients.

This is highly important.  As this basically allows client to self authorize.  There are situations where this can be a good thing, but they are pretty rare.

Some thought I will likely be needed to decide an appropriate way to to protect this version token grant_type, in my case I will be using a custom client model and a flag, but that may not be suitable for all cases.
