### PR TITLE
Fixed import location for Django 1.5.1 support.

### DIFF
--- a/oauth2app/authorize.py
+++ b/oauth2app/authorize.py
@@ -6,7 +6,11 @@
 
 try: import simplejson as json
 except ImportError: import json
-from django.http import absolute_http_url_re, HttpResponseRedirect
+from django.http import HttpResponseRedirect
+try: # Django >= 1.5
+    from django.http.request import absolute_http_url_re
+except ImportError: # Django < 1.5
+    from django.http import absolute_http_url_re
 from urllib import urlencode
 from .consts import ACCESS_TOKEN_EXPIRATION, REFRESHABLE
 from .consts import CODE, TOKEN, CODE_AND_TOKEN


### PR DESCRIPTION
`django.http` has been split out into separate modules in Django 1.5.x, and `absolute_http_url_re` is no longer available from the root of the `django.http` package. This commit tries to import from its new (>=1.5) location, falling back to its old location if it's not there.
